### PR TITLE
Fixbugs #43

### DIFF
--- a/components/LogTable.tsx
+++ b/components/LogTable.tsx
@@ -9,7 +9,7 @@ export default function LogView({userTokus}) {
 
     const date = obj.createdAt.toDate();
     const day = date.getDate();
-    const month = date.getMonth();
+    const month = date.getMonth() + 1;
     const formatted = ` ${month}/${day}`;
     array.push(formatted);
     return array;

--- a/components/PeopleLog.tsx
+++ b/components/PeopleLog.tsx
@@ -34,7 +34,7 @@ export default function PeopleLog() {
   const allTimeArr = allUserTokus.map((obj) => {
     const date = obj.createdAt.toDate();
     const day = date.getDate();
-    const month = date.getMonth();
+    const month = date.getMonth() + 1;
     const formatted = ` ${month}/${day}`;
     return formatted;
   });


### PR DESCRIPTION
https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth
>返値 地方時に基づき、与えた日付の「月」を表す 0 から 11 までの間の整数値。0 は 1 月、1 は 2 月、11 は 12 月に対応します。
getMonth() の使い方ミスって表示月がずれてたの直しました！
